### PR TITLE
remove 'bottle: unneeded', fix brew warnings. fix #18

### DIFF
--- a/ascii2svg.rb
+++ b/ascii2svg.rb
@@ -3,7 +3,6 @@ class Ascii2svg < Formula
   desc "ascii2svg"
   homepage "https://manfred.life/"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/ascii2svg/releases/download/v1.0.0/ascii2svg_1.0.0_Darwin_x86_64.tar.gz"

--- a/cryptoguess.rb
+++ b/cryptoguess.rb
@@ -3,7 +3,6 @@ class Cryptoguess < Formula
   desc "cryptoguess"
   homepage "https://manfred.life/"
   version "1.2.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/cryptoguess/releases/download/v1.2.0/cryptoguess_1.2.0_Darwin_x86_64.tar.gz"

--- a/depviz.rb
+++ b/depviz.rb
@@ -3,7 +3,6 @@ class Depviz < Formula
   desc "Issue dependency visualizer, a.k.a. 'auto-roadmap'."
   homepage "https://manfred.life/depviz"
   version "3.1.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/depviz/releases/download/v3.1.0/depviz_3.1.0_darwin_amd64.tar.gz"

--- a/dl.rb
+++ b/dl.rb
@@ -3,7 +3,6 @@ class Dl < Formula
   desc "dl"
   homepage "https://manfred.life/"
   version "1.7.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/dl/releases/download/v1.7.0/dl_1.7.0_Darwin_x86_64.tar.gz"

--- a/golang-repo-template.rb
+++ b/golang-repo-template.rb
@@ -3,7 +3,6 @@ class GolangRepoTemplate < Formula
   desc "golang-repo-template"
   homepage "https://manfred.life/"
   version "1.2.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/anonuuid/releases/download/v1.2.1/anonuuid_1.2.1_Darwin_x86_64.tar.gz"

--- a/graphman.rb
+++ b/graphman.rb
@@ -3,7 +3,6 @@ class Graphman < Formula
   desc "graph manipulation library and tool"
   homepage "https://manfred.life/"
   version "1.4.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/graphman/releases/download/v1.4.0/graphman_1.4.0_darwin_amd64.tar.gz"

--- a/hacker-typing.rb
+++ b/hacker-typing.rb
@@ -3,7 +3,6 @@ class HackerTyping < Formula
   desc "hacker-typing"
   homepage "https://manfred.life/"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/hacker-typing/releases/download/v1.0.0/hacker-typing_1.0.0_Darwin_x86_64.tar.gz"

--- a/metronome.rb
+++ b/metronome.rb
@@ -3,7 +3,6 @@ class Metronome < Formula
   desc "metronome"
   homepage "https://manfred.life/"
   version "1.0.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/metronome/releases/download/v1.0.0/metronome_1.0.0_Darwin_x86_64.tar.gz"

--- a/moulsay.rb
+++ b/moulsay.rb
@@ -3,7 +3,6 @@ class Moulsay < Formula
   desc "moulsay"
   homepage "https://manfred.life/"
   version "1.2.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/moulsay/releases/download/v1.2.0/moulsay_1.2.0_Darwin_x86_64.tar.gz"

--- a/number-to-words.rb
+++ b/number-to-words.rb
@@ -3,7 +3,6 @@ class NumberToWords < Formula
   desc "number-to-words"
   homepage "https://manfred.life/"
   version "0.5.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/number-to-words/releases/download/v0.5.0/number-to-words_0.5.0_Darwin_x86_64.tar.gz"

--- a/retry.rb
+++ b/retry.rb
@@ -3,7 +3,6 @@ class Retry < Formula
   desc "retry: repeat shell commands"
   homepage "https://manfred.life/"
   version "0.6.0"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/moul/retry/releases/download/v0.6.0/retry_0.6.0_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Warning: Calling bottle :unneeded is deprecated! There is no replacement.